### PR TITLE
Extend oEmbed support to include K-Box document embed

### DIFF
--- a/source/_assets/js/main.js
+++ b/source/_assets/js/main.js
@@ -479,6 +479,7 @@ window.App = function (config) {
 
                         if(oembed){
                             Oembed.resolve(oembed).then(function (embed) {
+                                console.info('oEmbed resolved', embed);
                                 result.hasEmbed = true;
                                 result.embed = embed.html;
                                 result.thumbnail = embed.thumbnail_url || result.thumbnail;

--- a/source/_assets/js/main.js
+++ b/source/_assets/js/main.js
@@ -467,28 +467,28 @@ window.App = function (config) {
                             result.app_url = result.url;
                         }
 
+                        var oembed = null;
+                        
+                        if(Oembed.hasProviderFor(result.originalUrl)){
+                            oembed = result.originalUrl;
+                        }
+
                         if (result.video && result.video.streaming && (result.video.streaming.dash || result.video.streaming.youtube || result.video.streaming.hls)) {
+                            oembed = result.video.streaming.dash || result.video.streaming.youtube || result.video.streaming.hls || null;
+                        }
 
-                            var stream = result.video.streaming.dash || result.video.streaming.youtube || result.video.streaming.hls || null;
-
-                            if (stream) {
-
-                                Oembed.resolve(stream).then(function (embed) {
-                                    result.hasEmbed = true;
-                                    result.embed = embed.html;
-                                    result.thumbnail = embed.thumbnail_url || result.thumbnail;
-                                    container.innerHTML = _renderer.render(template, { data: result });
-                                }).
-                                    catch(function () {
-                                        result.hasEmbed = true;
-                                        result.embed = '<div class="error">Player could not be loaded. <a class="inline-block no-underline p-2 bg-blue hover:bg-blue-dark focus:bg-blue-dark active:bg-blue-darker transition outline-none text-white shadow hover:shadow-raised hover:translateY-2px" href="' + result.url + '">Visit ' + result.url + ' to watch</a>.</div>';
-                                        container.innerHTML = _renderer.render(template, { data: result });
-                                    });
-                            }
-                            else {
+                        if(oembed){
+                            Oembed.resolve(oembed).then(function (embed) {
+                                result.hasEmbed = true;
+                                result.embed = embed.html;
+                                result.thumbnail = embed.thumbnail_url || result.thumbnail;
                                 container.innerHTML = _renderer.render(template, { data: result });
-                            }
-
+                            }).
+                            catch(function () {
+                                result.hasEmbed = true;
+                                result.embed = '<div class="error">Embed could not be loaded. <a class="inline-block no-underline p-2 bg-blue hover:bg-blue-dark focus:bg-blue-dark active:bg-blue-darker transition outline-none text-white shadow hover:shadow-raised hover:translateY-2px" href="' + result.url + '">Visit ' + result.url + '</a>.</div>';
+                                container.innerHTML = _renderer.render(template, { data: result });
+                            });
                         }
                         else {
                             container.innerHTML = _renderer.render(template, { data: result });

--- a/source/_assets/js/utils/oembed.js
+++ b/source/_assets/js/utils/oembed.js
@@ -175,6 +175,7 @@ module.exports = (function(){
                 resolve(oembedURL.url);
 
             }).then(function(oembedURL){
+
                 return httpGet(oembedURL, {
                     format: "json",
                     url: encodeURIComponent(url)

--- a/source/_assets/js/utils/oembed.js
+++ b/source/_assets/js/utils/oembed.js
@@ -27,6 +27,22 @@ module.exports = (function(){
             "url": "https://public.klink.asia/video/oembed"
         },
         {
+            "provider_name": "K-Box on klink.asia",
+            "provider_url": "https://klink.asia/",
+            "schemes": [
+                "https://*.klink.asia/d/show/*",
+            ],
+            "url": "https://{d}.klink.asia/api/oembed"
+        },
+        {
+            "provider_name": "K-Box on k-box.net",
+            "provider_url": "https://k-box.net/",
+            "schemes": [
+                "https://*.k-box.net/d/show/*",
+            ],
+            "url": "https://{d}.k-box.net/api/oembed"
+        },
+        {
             "provider_name": "YouTube",
             "provider_url": "https://www.youtube.com/",
             "url": "https://www.youtube.com/oembed",
@@ -109,7 +125,12 @@ module.exports = (function(){
                 
                 var reg = new RegExp(scheme.replace(/\*/g, '(.*)'), 'i');
                 if(url.match(reg)){
-                    providerUrl = provider.url;
+                    providerUrl = {
+                        provider_name: provider.provider_name,
+                        provider_url: provider.provider_url,
+                        scheme: scheme,
+                        url: provider.url,
+                    };
                 }
             }
 
@@ -126,6 +147,10 @@ module.exports = (function(){
         findProvider: function(url){
             return findProviderFor(url);
         },
+        
+        hasProviderFor: function(url){
+            return findProviderFor(url) !== null;
+        },
 
         resolve: function(url){
 
@@ -136,8 +161,18 @@ module.exports = (function(){
                 if(!oembedURL){
                     reject(new TypeError("Embed not supported"));
                 }
+
+                var reg = new RegExp(oembedURL.scheme.replace(/\*/g, '(.*)'), 'i');
+
+                var matches = url.match(reg);
+
+                if(matches.length === 3){
+                    // we have to replace the domain in the url
+
+                    resolve(oembedURL.url.replace(/{d}/g, matches[1]));
+                }
     
-                resolve(oembedURL);
+                resolve(oembedURL.url);
 
             }).then(function(oembedURL){
                 return httpGet(oembedURL, {

--- a/source/_partials/templates/single.blade.php
+++ b/source/_partials/templates/single.blade.php
@@ -5,17 +5,23 @@
 
 		<div class="bg-grey-dark min-h-64 py-4 mb-4">
 			<div class="container text-white">
-				{{#isVideo}}
-					{{#hasEmbed}}
-						{{{ embed }}}
-					{{/hasEmbed}}
-					{{^hasEmbed}}
+				
+				{{#hasEmbed}}
+					{{{ embed }}}
+				{{/hasEmbed}}
+
+				{{^hasEmbed}}
+					{{#isVideo}}
 						<video class="preview__video" src="{{{ url }}}" poster="{{{ thumbnail }}}" controls preload="none"></video>
-					{{/hasEmbed}}
-				{{/isVideo}}
+					{{/isVideo}}
+				{{/hasEmbed}}
+
+				
 				
 				{{^isVideo}}
-					<img class="preview__image block min-h-64 h-half-screen" src="{{{ thumbnail }}}" alt="{{{title}}}">
+					{{^hasEmbed}}
+						<img class="preview__image block min-h-64 h-half-screen" src="{{{ thumbnail }}}" alt="{{{title}}}">
+					{{/hasEmbed}}
 				{{/isVideo}}
 			</div>
 		</div>


### PR DESCRIPTION
The support of oEmbed at the K-Box level https://github.com/k-box/k-box/pull/145 implies that we can use it to deliver a richer experience when browsing search results. Like it was done for videos on the K-Link the oEmbed support will be based on whitelisting K-Box domains.

A nice addition to the original implementation is that the provider can now have a placeholder for subdomains, so multiple K-Boxes on the same domain do not need to be registered one by one