### PR TITLE
Fix mime type filter not selected

### DIFF
--- a/source/_assets/js/main.js
+++ b/source/_assets/js/main.js
@@ -322,11 +322,15 @@ window.App = function (config) {
             
             result.push({
                 label: aggregationMapping.values && aggregationMapping.values[v.value] ? aggregationMapping.values[v.value] : null,
-                value: (aggregation === "mime_type") ? v.value.replace("/", "-") :  v.value,
+                value: (aggregation === "mime_type") ? ensureMimeTypeIsValidSelector(v.value) :  v.value,
             });
         }, []);
         
         return mapped;
+    }
+
+    function ensureMimeTypeIsValidSelector(mime){
+        return mime.replace("/", "-").replace(".", "_");
     }
 
     function initializeFilterUI(filtersSelector, searchFormSelector){
@@ -395,7 +399,7 @@ window.App = function (config) {
                 
                 if(_searchStatus.selectedFilters.mime_type && _searchStatus.selectedFilters.mime_type.length > 0){
                     activeFilters.mime_type = flattenDeep(map(processedFilters.mime_type, function(v){
-                        return v.replace("-", "/");
+                        return v.replace("-", "/").replace("_", "."); // apply the inverse of the normalization for making the mime type a valid selector
                     }));
                 }
 

--- a/source/_assets/js/main.js
+++ b/source/_assets/js/main.js
@@ -330,7 +330,7 @@ window.App = function (config) {
     }
 
     function ensureMimeTypeIsValidSelector(mime){
-        return mime.replace("/", "-").replace(".", "_");
+        return mime.replace("/", "-").replace(/\./g, "_");
     }
 
     function initializeFilterUI(filtersSelector, searchFormSelector){
@@ -399,7 +399,7 @@ window.App = function (config) {
                 
                 if(_searchStatus.selectedFilters.mime_type && _searchStatus.selectedFilters.mime_type.length > 0){
                     activeFilters.mime_type = flattenDeep(map(processedFilters.mime_type, function(v){
-                        return v.replace("-", "/").replace("_", "."); // apply the inverse of the normalization for making the mime type a valid selector
+                        return v.replace("-", "/").replace(/_/g, "."); // apply the inverse of the normalization for making the mime type a valid selector
                     }));
                 }
 


### PR DESCRIPTION
This pull request fixes the case when selected mime type filter are not anymore selected after triggering a search.

The issue was caused by a partial normalization of mime type values to become valid selectors for the `document.querySelector` api. Now the mime type is normalized by removing both `/` and `.` for the presentational purpose. This will invalidate all existing direct links to search results that have mime types filter with dots in the value, e.g. `application/vnd.ms-powerpoint`

A mime type is now normalized as follows

- First slash `/` is replaced with dash `-`
- First dot `.` is replaced with underscore `_`